### PR TITLE
Extend models with credit_notes and items

### DIFF
--- a/lib/billomat/models.rb
+++ b/lib/billomat/models.rb
@@ -2,6 +2,8 @@
 
 require 'billomat/models/base'
 require 'billomat/models/client'
+require 'billomat/models/credit_note'
+require 'billomat/models/credit_note_item'
 require 'billomat/models/invoice'
 require 'billomat/models/invoice_item'
 require 'billomat/models/invoice_payment'

--- a/lib/billomat/models/credit_note.rb
+++ b/lib/billomat/models/credit_note.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Billomat
+  module Models
+    ##
+    # Representation of the credit note resource
+    class CreditNote < Base
+      # @return [String] The resource's base path
+      def self.base_path
+        '/credit-notes'
+      end
+
+      # @return [String] The resource's name
+      def self.resource_name
+        'credit-note'
+      end
+    end
+  end
+end

--- a/lib/billomat/models/credit_note_item.rb
+++ b/lib/billomat/models/credit_note_item.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Billomat
+  module Models
+    ##
+    # Representation of the credit note item resource
+    class CreditNoteItem < Base
+      # @return [String] The resource's base path
+      def self.base_path
+        '/credit-note-items'
+      end
+
+      # @return [String] The resource's name
+      def self.resource_name
+        'credit-note-item'
+      end
+    end
+  end
+end

--- a/spec/models/credit_note_item_spec.rb
+++ b/spec/models/credit_note_item_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Billomat::Models::CreditNoteItem do
+  it 'has a base path' do
+    expect(described_class.base_path).to be
+  end
+
+  it 'has a resource name' do
+    expect(described_class.resource_name).to be
+  end
+end

--- a/spec/models/credit_note_spec.rb
+++ b/spec/models/credit_note_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Billomat::Models::CreditNote do
+  it 'has a base path' do
+    expect(described_class.base_path).to be
+  end
+
+  it 'has a resource name' do
+    expect(described_class.resource_name).to be
+  end
+end


### PR DESCRIPTION
To create credit note in billomat 2 more models are needed in the gem:

- credit_note
- credit_note_item

Usage is similar to invoice and invoice_item.
(https://www.billomat.com/api/gutschriften/)