### PR TITLE
Add after_response callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### next
 
 * Moved the development dependencies from the gemspec to the Gemfile (#19)
+* Introduce `after_response` callback (#22)
 
 ### 1.1.0
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ Billomat.configure do |config|
   # https://www.billomat.com/en/api/basics/rate-limiting/
   config.app_id = '12345'
   config.app_secret = 'c3df...'
+
+  config.after_response = lambda do |response|
+    # API response callback, e.g. for inspecting the rate limit
+    # header via response.headers[:x_rate_limit_remaining]
+  end
 end
 ```
 

--- a/lib/billomat/configuration.rb
+++ b/lib/billomat/configuration.rb
@@ -4,5 +4,17 @@ module Billomat
   # The +billomat+ gem configuration.
   class Configuration
     attr_accessor :api_key, :subdomain, :timeout, :app_id, :app_secret
+    attr_reader :after_response
+
+    # Sets a callback to be called for each API response
+    #
+    # @param [Proc] callback The callback
+    def after_response=(callback)
+      unless callback.respond_to?(:call)
+        raise ArgumentError, "callback must respond to `call'"
+      end
+
+      @after_response = callback
+    end
   end
 end

--- a/lib/billomat/gateway.rb
+++ b/lib/billomat/gateway.rb
@@ -68,7 +68,7 @@ module Billomat
         timeout: timeout,
         headers: headers,
         payload: body.to_json
-      )
+      ).tap { |response| Billomat.configuration.after_response&.call(response) }
     end
 
     # @return [String] the complete URL for the request

--- a/spec/billomat/configuration_spec.rb
+++ b/spec/billomat/configuration_spec.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Billomat::Configuration do
+  let(:configuration) { described_class.new }
+
+  describe '.after_response=' do
+    it 'sets after_response' do
+      callback = proc {}
+      configuration.after_response = callback
+      expect(configuration.after_response).to eq(callback)
+    end
+
+    it 'raises an error when assigned a non proc' do
+      expect { configuration.after_response = :foo }.to raise_error(ArgumentError)
+    end
+  end
+end

--- a/spec/billomat/gateway_spec.rb
+++ b/spec/billomat/gateway_spec.rb
@@ -32,6 +32,8 @@ RSpec.describe Billomat::Gateway do
   end
 
   describe '#run' do
+    let(:callback) { instance_double(Proc) }
+
     context 'when API Call is successful' do
       let(:execute_args) do
         {
@@ -50,6 +52,13 @@ RSpec.describe Billomat::Gateway do
         expect(RestClient::Request).to \
           receive(:execute).with(hash_including(**execute_args))
 
+        gateway.new(:get, '/clients', foo: 'bar').run
+      end
+
+      it 'invokes after_response callback with response' do
+        expect(callback).to receive(:call).with(good_response)
+
+        Billomat.configuration.after_response = callback
         gateway.new(:get, '/clients', foo: 'bar').run
       end
     end


### PR DESCRIPTION
Billomat's API comes with [rate limiting](https://www.billomat.com/api/grundlagen/zugriffsbegrenzung/) which is currently not handled by the Billomat gem. And since the current rate limit values are included in the response headers which are not exposed by the Billomat gem, there's no easy way to account for a proper rate limit handling either.

Therefore, I've added a simple callback mechanism that's invoked upon API requests (or API responses to be more precise). It can be used like this:

```ruby
Billomat::Gateway.on_api_call = lambda do |response|
  remaining = response.headers[:x_rate_limit_remaining].to_i
  reset     = response.headers[:x_rate_limit_reset].to_i

  if limit < 10
    # stop processing until "reset"
  end
end
```

Since `on_api_call` can be anything that responds to `call`, you could also have a custom class handle the callback, e.g.

```ruby
Billomat::Gateway.on_api_call = MyRateLimitHandler

class MyRateLimitHandler
  def self.call(response)
    # ...
  end
end
```

or some method:

```ruby
Billomat::Gateway.on_api_call = MyRateLimitHandler.method(:billomat_api_call)

class MyRateLimitHandler
  def self.billomat_api_call(response)
    # ...
  end
end
```